### PR TITLE
Wrapping the HostApplicationBuilder

### DIFF
--- a/BackgroundServiceSandbox.sln
+++ b/BackgroundServiceSandbox.sln
@@ -1,5 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkServiceSeven", "WorkServiceSeven\WorkServiceSeven.csproj", "{E41402E8-09C1-4A75-AC79-7852B74DC42D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkServiceEight", "WorkServiceEight\WorkServiceEight.csproj", "{0AEFA0C6-D795-48C8-9525-DC262E1D0933}"
@@ -7,6 +8,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core7Library", "Core7Library\Core7Library.csproj", "{6F1D3CF4-CDF5-4C76-A22F-A8E260E21349}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestingTime", "TestingTime\TestingTime.csproj", "{BE344C56-1269-48E0-BE52-A29BF35E3F67}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core8Library", "Core8Library\Core8Library.csproj", "{B47EC944-B3CE-4FF6-848D-AEF142BF455E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,5 +33,9 @@ Global
 		{BE344C56-1269-48E0-BE52-A29BF35E3F67}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE344C56-1269-48E0-BE52-A29BF35E3F67}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE344C56-1269-48E0-BE52-A29BF35E3F67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B47EC944-B3CE-4FF6-848D-AEF142BF455E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B47EC944-B3CE-4FF6-848D-AEF142BF455E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B47EC944-B3CE-4FF6-848D-AEF142BF455E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B47EC944-B3CE-4FF6-848D-AEF142BF455E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Core7Library/CatFacts/CatFactsClientService.cs
+++ b/Core7Library/CatFacts/CatFactsClientService.cs
@@ -1,8 +1,7 @@
-﻿using Core7Library.CatFacts;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Core7Library;
+namespace Core7Library.CatFacts;
 
 public class CatFactsClientService : RefitClientServiceBase<ICatFactsClient>, ICatFactsClientService
 {

--- a/Core7Library/CatFacts/CatFactsClientService.cs
+++ b/Core7Library/CatFacts/CatFactsClientService.cs
@@ -25,7 +25,7 @@ public class CatFactsClientService : RefitClientServiceBase<ICatFactsClient>, IC
         // Func<Task<ApiResponse<string?>>> taskWithSimpleReturn = () => Task.FromResult(new ApiResponse<string?>(null!, "foo", new()));
         // MakeRequestAsync(taskWithSimpleReturn);
 
-        return GetApiResponse(RefitClient.GetTheFactsAsync(_settings.GetTheFactsRoute, cancellationToken));
+        return GetApiResponse(RefitClient.GetTheFactsAsync(_settings.GetTheFactsRoute, cancellationToken), new List<CatFact>());
     }
 
     public Task<CatFact?> Explode(CancellationToken cancellationToken)

--- a/Core7Library/Core7Library.csproj
+++ b/Core7Library/Core7Library.csproj
@@ -15,6 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Autofac" Version="7.1.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />

--- a/Core7Library/Core7LibraryAutofacModule.cs
+++ b/Core7Library/Core7LibraryAutofacModule.cs
@@ -1,0 +1,14 @@
+﻿using Autofac;
+using Core7Library.BearerTokenStuff;
+using Core7Library.CatFacts;
+
+namespace Core7Library;
+
+public class Core7LibraryAutofacModule : Module
+{
+    protected override void Load(ContainerBuilder builder)
+    {
+        builder.RegisterType<CatFactsClientService>().As<ICatFactsClientService>();
+        builder.RegisterType<OAuthClientService>().As<IOAuthClientService>();
+    }
+}

--- a/Core7Library/RefitClientServiceBase.cs
+++ b/Core7Library/RefitClientServiceBase.cs
@@ -98,7 +98,6 @@ public abstract class RefitClientServiceBase<TRefitClient>
         {
             Logger.LogError(ex, "[{ClientServiceName}.{RequestMethodName}] HTTP request succeeded, but a JsonException was thrown on deserialization",
                 GetType().Name, caller);
-            return defaultOnError;
         }
         catch (ApiException ex)
         {
@@ -106,7 +105,12 @@ public abstract class RefitClientServiceBase<TRefitClient>
             string content = ex.Content.TryFormatJson() ?? "N/A";
             Logger.LogError(ex, "[{ClientServiceName}.{RequestMethodName}] HTTP request failed: {ReasonPhrase} | Content: {Content}",
                 GetType().Name, caller, reasonPhrase, content);
-            return defaultOnError;
         }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[{ClientServiceName}.{RequestMethodName}] HTTP request failed due to exception",
+                GetType().Name, caller);
+        }
+        return defaultOnError;
     }
 }

--- a/Core8Library/Core8Library.csproj
+++ b/Core8Library/Core8Library.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
+    <PackageReference Include="Refit" Version="7.0.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core7Library\Core7Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Core8Library/Core8Library.csproj
+++ b/Core8Library/Core8Library.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="7.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />

--- a/Core8Library/Core8Library.csproj
+++ b/Core8Library/Core8Library.csproj
@@ -17,19 +17,19 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="7.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageReference Include="Refit" Version="7.0.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/Core8Library/HostValidationException.cs
+++ b/Core8Library/HostValidationException.cs
@@ -1,4 +1,4 @@
 namespace Core8Library;
 
-public class HostValidationException(string message)
+internal class HostValidationException(string message)
     : ApplicationException($"Exception occurred when validating the created Host: {message}");

--- a/Core8Library/HostValidationException.cs
+++ b/Core8Library/HostValidationException.cs
@@ -1,0 +1,4 @@
+namespace Core8Library;
+
+public class HostValidationException(string message)
+    : ApplicationException($"Exception occurred when validating the created Host: {message}");

--- a/Core8Library/HostValidator.cs
+++ b/Core8Library/HostValidator.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Core8Library;
+
+internal static class HostValidator
+{
+    /// <summary>
+    /// Validates each of the settings types given (DataAnnotations, and any database connection strings);
+    /// also validates that Serilog does not throw when logging (i.e. has permissions to write to file)
+    /// </summary>
+    /// <param name="host">The created <see cref="IHost"/> instance</param>
+    /// <param name="settingsTypesToValidate">Collection of types that represent settings, to be validated</param>
+    /// <exception cref="ApplicationException">Thrown if any validation error occurs</exception>
+    public static void Validate(IHost host, List<Type> settingsTypesToValidate)
+    {
+        // Validates Serilog
+        EnableSerilogValidation();
+        var logger = host.Services.GetRequiredService<ILogger<SuperHostBuilder>>();
+        logger.LogDebug("[{Validator}] Beginning validation", nameof(HostValidator));
+        Serilog.Debugging.SelfLog.Disable();
+
+        // Validates all settings
+        bool allSettingsValid = settingsTypesToValidate.All(t => ValidateSettings(t, host.Services, logger));
+        if (!allSettingsValid)
+        {
+            throw new HostValidationException("Not all settings were found to be valid");
+        }
+    }
+
+    private static bool ValidateSettings(Type settingsToValidate, IServiceProvider services, ILogger logger)
+    {
+        try
+        {
+            // TODO: Fetch Options<TSettings>.
+            // TODO: If a connection string is present, validate that as well.
+            // var options = services.GetRequiredService(typeof(IOptions<object>));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[{Validator}] {SettingsType} validation error", nameof(HostValidator), settingsToValidate.Name);
+            return false;
+        }
+    }
+
+    private static void EnableSerilogValidation()
+    {
+        Serilog.Debugging.SelfLog.Enable(message =>
+        {
+            string appIdentifier = Assembly.GetExecutingAssembly().FullName?.Split(",").FirstOrDefault() ?? "Program";
+            var logPath = Path.Join(AppContext.BaseDirectory, $"[{DateTime.UtcNow:yyyy-MM-dd HH.mm.ss}]-[{appIdentifier}]-SerilogError.txt");
+            var messageToLog = $"[{nameof(HostValidator)}] Serilog Validation Error - {message}";
+            try
+            {
+                File.AppendAllText(logPath, messageToLog);
+                throw new HostValidationException($"[{nameof(HostValidator)}] Serilog Validation Error - Check [{logPath}] for errors");
+            }
+            catch (Exception ex)
+            {
+                // Last resort. Most likely means we won't see these errors when running as a Windows service
+                Console.WriteLine($"[{nameof(HostValidator)}] Serilog Validation Error: {message}");
+                Console.WriteLine($"[{nameof(HostValidator)}] COULD NOT WRITE THIS TO FILE: {ex}");
+                throw new HostValidationException($"Serilog Validation Error: {message}{Environment.NewLine}COULD NOT WRITE THIS EXCEPTION TO FILE: {ex}");
+            }
+        });
+    }
+}

--- a/Core8Library/SuperAutofacModule.cs
+++ b/Core8Library/SuperAutofacModule.cs
@@ -12,7 +12,7 @@ namespace Core8Library;
 /// <param name="concreteTypesToIgnore">
 /// Types for Autofac to ignore; pass the implementation type, not the interface type
 /// </param>
-public class SuperAutofacModule(params Type[] concreteTypesToIgnore) : AutofacModule
+internal class SuperAutofacModule(params Type[] concreteTypesToIgnore) : AutofacModule
 {
     protected override void Load(ContainerBuilder builder)
     {

--- a/Core8Library/SuperAutofacModule.cs
+++ b/Core8Library/SuperAutofacModule.cs
@@ -1,0 +1,42 @@
+﻿using System.Reflection;
+using Autofac;
+using Autofac.Core;
+using Microsoft.Extensions.Hosting;
+using AutofacModule = Autofac.Module;
+
+namespace Core8Library;
+
+/// <summary>
+/// Registers dependencies inside this class library, as well as those of the Worker
+/// </summary>
+/// <param name="concreteTypesToIgnore">
+/// Types for Autofac to ignore; pass the implementation type, not the interface type
+/// </param>
+public class SuperAutofacModule(params Type[] concreteTypesToIgnore) : AutofacModule
+{
+    protected override void Load(ContainerBuilder builder)
+    {
+        var interfacesToExclude = new[]
+        {
+            typeof(IHostedService), // Hosted Services (added outside Autofac)
+            typeof(IModule) // Autofac Modules
+        };
+        Assembly thisAssembly = GetType().Assembly;
+        Assembly workerAssembly = Assembly.GetEntryAssembly()!; // Confirmed working for EXE and when running as a Service
+        builder.RegisterAssemblyTypes(thisAssembly, workerAssembly)
+            .Where(t => !concreteTypesToIgnore.Contains(t))
+            .Where(t => !t.FullName?.StartsWith("Refit.Implementation") ?? false)
+            .Where(t => !t.GetInterfaces().Any(i => interfacesToExclude.Contains(i)))
+            .AsImplementedInterfaces(); // Automatic registration of IFoo -> Foo etc.
+
+        // Singleton registration + registering .NET 8's TimeProvider
+        builder
+            .RegisterInstance(TimeProvider.System)
+            .As<TimeProvider>()
+            .SingleInstance();
+
+        // Uncomment and debug to view all the things Autofac will do
+        // Application will not start if left uncommented
+        // var registeredComponents = builder.Build().ComponentRegistry.Registrations;
+    }
+}

--- a/Core8Library/SuperHostBuilder.cs
+++ b/Core8Library/SuperHostBuilder.cs
@@ -1,4 +1,6 @@
-﻿using Core7Library;
+﻿using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Core7Library;
 using Core7Library.BearerTokenStuff;
 using Core7Library.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,8 +26,8 @@ public class SuperHostBuilder
     private SuperHostBuilder() { }
 
     /// <summary>
-    /// Creates an <see cref="IHost" /> and performs validation on configured settings,
-    /// running through DataAnnotations and more
+    /// Creates an <see cref="IHost" /> and performs validation on configured settings (DataAnnotations, connection strings)
+    /// and the configured logger (make sure it can write to file if configured to do so)
     /// </summary>
     /// <returns>An <see cref="IHost"/> that can be run</returns>
     /// <exception cref="ApplicationException">Thrown when a validation error occurs</exception>
@@ -36,7 +38,7 @@ public class SuperHostBuilder
         {
             AuthBearerTokenFactory.SetBearerTokenGetterFunc(token => _getBearerTokenAsyncFunc(host, token));
         }
-        // TODO: Config validation
+        HostValidator.Validate(host, _settingsTypes);
         return host;
     }
 
@@ -129,24 +131,6 @@ public class SuperHostBuilder
     {
         _builder.Services.AddRequiredSettings<TSettings>();
         _settingsTypes.Add(typeof(TSettings));
-        return _builder.Configuration.GetRequiredSettings<TSettings>();
-    }
-
-    /// <summary>
-    /// Get an instance of settings from config
-    /// </summary>
-    /// <remarks>
-    /// <see cref="WithSettings{TSettings}"/> must be called prior to calling this
-    /// </remarks>
-    /// <exception cref="InvalidOperationException">Thrown when this method is called before calling <see cref="WithSettings{TSettings}"/></exception>
-    public TSettings GetSettings<TSettings>()
-        where TSettings : class
-    {
-        var settingsType = typeof(TSettings);
-        if (!_settingsTypes.Contains(settingsType))
-        {
-            throw new InvalidOperationException($"Cannot call {nameof(GetSettings)}<{settingsType.Name}> without calling {nameof(WithSettings)}<{settingsType.Name}> first.");
-        }
         return _builder.Configuration.GetRequiredSettings<TSettings>();
     }
 

--- a/Core8Library/SuperHostBuilder.cs
+++ b/Core8Library/SuperHostBuilder.cs
@@ -1,0 +1,158 @@
+﻿using Core7Library;
+using Core7Library.BearerTokenStuff;
+using Core7Library.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Refit;
+using Serilog;
+
+namespace Core8Library;
+
+/// <summary>
+/// Largely a wrapper around <see cref="HostApplicationBuilder"/>, but with additional state and restrictions
+/// in place so that consumers are forced to perform validation, provide OAuth mechanisms (when the need
+/// arises), etc.
+/// </summary>
+public class SuperHostBuilder
+{
+    private readonly HostApplicationBuilder _builder = Host.CreateApplicationBuilder();
+    private readonly List<Type> _settingsTypes = new();
+    private Func<CancellationToken, Task<string>>? _getBearerTokenAsyncFunc = null;
+
+    private SuperHostBuilder() { }
+
+    /// <summary>
+    /// Creates an <see cref="IHost" /> and performs validation on configured settings,
+    /// running through DataAnnotations and more
+    /// </summary>
+    /// <returns>An <see cref="IHost"/> that can be run</returns>
+    /// <exception cref="ApplicationException">Thrown when a validation error occurs</exception>
+    public IHost BuildAndValidate()
+    {
+        IHost host = _builder.Build();
+        if (_getBearerTokenAsyncFunc is not null)
+        {
+            AuthBearerTokenFactory.SetBearerTokenGetterFunc(_getBearerTokenAsyncFunc);
+        }
+        // TODO: Config validation
+        return host;
+    }
+
+    /// <summary>
+    /// Registers dependencies for this library as well as for the calling service's
+    /// </summary>
+    public SuperHostBuilder WithDependenciesRegistered()
+    {
+        // TODO: Autofac
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the specified serviced as a Hosted Service and Windows Service
+    /// </summary>
+    public SuperHostBuilder WithHostedWindowsService<THostedService>()
+        where THostedService : class, IHostedService
+    {
+        _builder.Services.AddHostedService<THostedService>();
+        _builder.Services.AddWindowsService();
+        return this;
+    }
+
+    /// <summary>
+    /// Adds Serilog logging, configured from file
+    /// </summary>
+    public SuperHostBuilder WithLogging()
+    {
+        _builder.Services.AddSerilog(config => config.ReadFrom.Configuration(_builder.Configuration));
+        return this;
+    }
+
+    /// <summary>
+    /// Configures <typeparamref name="TClientInterface"/> as a Refit client, setting other conventional defaults.
+    /// </summary>
+    /// <param name="configureHttpClient">Action to take when configuring the <see cref="HttpClient"/></param>
+    /// <param name="getBearerTokenAsyncFunc">When provided, will configure Refit to attempt to fetch a bearer token from <see cref="AuthBearerTokenFactory"/></param>
+    /// <param name="enableRequestResponseLogging">When true, will log every single HTTP request and response using <see cref="HttpLoggingHandler"/></param>
+    /// <param name="disableAutoRedirect">
+    /// When true, will attempt to disable the ability for this client to do redirects when making HTTP calls.
+    /// Typically, one might do this to prevent redirects to login pages when trying to use an API.
+    /// </param>
+    /// <param name="handlerLifetimeInMinutes">
+    /// How long the handler should live for before it is renewed. In long-running applications and services,
+    /// set this to a low value because they're meant to be short-lived. Default is 10 minutes.
+    /// </param>
+    /// <typeparam name="TClientInterface">A Refit client interface.</typeparam>
+    /// <returns>The builder used to build this client, to allow for further customization if needed.</returns>
+    public SuperHostBuilder WithRefitClient<TClientInterface>(Action<HttpClient> configureHttpClient, Func<CancellationToken, Task<string>>? getBearerTokenAsyncFunc = null, bool enableRequestResponseLogging = false,
+        bool disableAutoRedirect = false, int handlerLifetimeInMinutes = 10)
+        where TClientInterface : class
+    {
+        RefitSettings? refitSettings = null;
+        if (getBearerTokenAsyncFunc is not null)
+        {
+            _getBearerTokenAsyncFunc = getBearerTokenAsyncFunc;
+            refitSettings = new RefitSettings
+            {
+                AuthorizationHeaderValueGetter = (_, cancellationToken) => AuthBearerTokenFactory.GetBearerTokenAsync(cancellationToken)
+            };
+        }
+        var builder = _builder.Services.AddRefitClient<TClientInterface>(refitSettings);
+        if (disableAutoRedirect) builder = builder.DisableAutoRedirect();
+        builder
+            .ConfigureHttpClient(configureHttpClient)
+            .SetHandlerLifetime(TimeSpan.FromMinutes(handlerLifetimeInMinutes));
+        if (enableRequestResponseLogging)
+        {
+            // Cannot use builder.AddHttpMessageHandler<HttpLoggingHandler>, because Refit and DI mingling throws an exception.
+            // See https://github.com/reactiveui/refit/issues/1403#issuecomment-1499380557 for workaround source
+            builder.AddHttpMessageHandler(svc => new HttpLoggingHandler(svc.GetRequiredService<ILogger<HttpLoggingHandler>>()));
+            builder.Services.AddSingleton<HttpLoggingHandler>(); // Calling this multiple times seems to be fine.
+        }
+        return this;
+    }
+
+    // TODO: Perform validation here? Logging might not be set up yet though.
+    /// <summary>
+    /// Configures settings for a particular type, setting up DataAnnotations validation
+    /// for them and making them available throughout the application by injecting
+    /// <see cref="IOptions{TOptions}"/> into a constructor
+    /// </summary>
+    public SuperHostBuilder WithSettings<TSettings>()
+        where TSettings : class
+    {
+        _builder.Services.AddRequiredSettings<TSettings>();
+        _settingsTypes.Add(typeof(TSettings));
+        return this;
+    }
+
+    /// <summary>
+    /// Get an instance of settings from config
+    /// </summary>
+    /// <remarks>
+    /// <see cref="WithSettings{TSettings}"/> must be called prior to calling this
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown when this method is called before calling <see cref="WithSettings{TSettings}"/></exception>
+    public TSettings GetSettings<TSettings>()
+        where TSettings : class
+    {
+        var settingsType = typeof(TSettings);
+        if (!_settingsTypes.Contains(settingsType))
+        {
+            throw new InvalidOperationException($"Cannot call {nameof(GetSettings)}<{settingsType.Name}> without calling {nameof(WithSettings)}<{settingsType.Name}> first.");
+        }
+        return _builder.Configuration.GetRequiredSettings<TSettings>();
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="SuperHostBuilder"/> configured to run as a Windows service,
+    /// with Serilog logging and dependencies registered with Autofac
+    /// </summary>
+    /// <typeparam name="THostedService">The worker service class to register</typeparam>
+    public static SuperHostBuilder Create<THostedService>() where THostedService : class, IHostedService
+        => new SuperHostBuilder()
+            .WithHostedWindowsService<THostedService>()
+            .WithLogging()
+            .WithDependenciesRegistered();
+}

--- a/Core8Library/SuperHostBuilder.cs
+++ b/Core8Library/SuperHostBuilder.cs
@@ -11,7 +11,7 @@ using Serilog;
 namespace Core8Library;
 
 /// <summary>
-/// Largely a wrapper around <see cref="HostApplicationBuilder"/>, but with additional state and restrictions
+/// A wrapper around <see cref="HostApplicationBuilder"/>, but with additional state and restrictions
 /// in place so that consumers are forced to perform validation, provide OAuth mechanisms (when the need
 /// arises), etc.
 /// </summary>
@@ -19,7 +19,7 @@ public class SuperHostBuilder
 {
     private readonly HostApplicationBuilder _builder = Host.CreateApplicationBuilder();
     private readonly List<Type> _settingsTypes = new();
-    private Func<CancellationToken, Task<string>>? _getBearerTokenAsyncFunc = null;
+    private Func<IHost, CancellationToken, Task<string>>? _getBearerTokenAsyncFunc = null;
 
     private SuperHostBuilder() { }
 
@@ -45,7 +45,8 @@ public class SuperHostBuilder
     /// </summary>
     public SuperHostBuilder WithDependenciesRegistered()
     {
-        // TODO: Autofac
+        _builder.ConfigureContainer<ContainerBuilder>(new AutofacServiceProviderFactory(),
+            containerBuilder => containerBuilder.RegisterModule(new SuperAutofacModule()));
         return this;
     }
 

--- a/WorkServiceEight/Program.cs
+++ b/WorkServiceEight/Program.cs
@@ -1,9 +1,10 @@
+using Core7Library;
 using Core7Library.BearerTokenStuff;
 using Core7Library.CatFacts;
 using Core8Library;
 using WorkServiceEight;
 
-SuperHostBuilder superBuilder = SuperHostBuilder.Create<Worker8>();
+SuperHostBuilder superBuilder = SuperHostBuilder.Create<Worker8>(new Core7LibraryAutofacModule());
 var mySettings = superBuilder.WithSettings<MySettings>();
 var catFactsSettings = superBuilder.WithSettings<CatFactsClientSettings>();
 IHost host = superBuilder

--- a/WorkServiceEight/Program.cs
+++ b/WorkServiceEight/Program.cs
@@ -6,12 +6,18 @@ using WorkServiceEight;
 SuperHostBuilder superBuilder = SuperHostBuilder.Create<Worker8>();
 var mySettings = superBuilder.WithSettings<MySettings>();
 var catFactsSettings = superBuilder.WithSettings<CatFactsClientSettings>();
-superBuilder.WithRefitClient<IOAuthClient>(c => c.BaseAddress = new Uri("https://example.com/"),
-    enableRequestResponseLogging: mySettings.EnableHttpRequestResponseLogging);
-superBuilder.WithRefitClient<IOAuthClient>(c => c.BaseAddress = new Uri(catFactsSettings.Host),
-    getBearerTokenAsyncFunc: GetBearerTokenAsyncFunc, enableRequestResponseLogging: mySettings.EnableHttpRequestResponseLogging);
-IHost host = superBuilder.BuildAndValidate();
+IHost host = superBuilder
+    .WithRefitClient<IOAuthClient>(c => c.BaseAddress = new Uri("https://example.com/"), enableRequestResponseLogging: mySettings.EnableHttpRequestResponseLogging)
+    .WithRefitClient<ICatFactsClient>(ConfigureCatFactsClient, getBearerTokenAsyncFunc: GetBearerTokenAsyncFunc, enableRequestResponseLogging: mySettings.EnableHttpRequestResponseLogging)
+    .BuildAndValidate();
+
 host.Run();
+
+void ConfigureCatFactsClient(HttpClient c)
+{
+    c.BaseAddress = new Uri(catFactsSettings.Host);
+    c.Timeout = TimeSpan.FromSeconds(3);
+}
 
 Task<string> GetBearerTokenAsyncFunc(IHost createdHost, CancellationToken token)
     => createdHost.Services.GetRequiredService<IOAuthClientService>().GetBearerTokenAsync(token);

--- a/WorkServiceEight/SomeProc.cs
+++ b/WorkServiceEight/SomeProc.cs
@@ -11,14 +11,8 @@ public class SomeProc(string name, ICatFactsClientService catFactsClientService)
     {
         DontStopMeNow = true;
         Console.WriteLine("Starting {0}. Don't stop me now!", Name);
-        // for (int delay = 0; delay < 10; delay++)
-        // {
-        //     Console.WriteLine("{0} working...", Name);
-        //     await Task.Delay(1000);
-        // }
-
-        // ApiResponse<List<CatFact>?> theFacts = await catFactsClient.GetTheFactsAsync("facts", CancellationToken.None);
-        // Console.WriteLine("{0} Done! Found {1} Cat Facts!", Name, theFacts.Content?.Count ?? 0);
+        List<CatFact> theFacts = await catFactsClientService.GetTheFactsAsync(cancellationToken);
+        Console.WriteLine("{0} Done! Found {1} Cat Facts!", Name, theFacts.Count);
         await catFactsClientService.Explode(cancellationToken);
         DontStopMeNow = false;
     }

--- a/WorkServiceEight/WorkServiceEight.csproj
+++ b/WorkServiceEight/WorkServiceEight.csproj
@@ -16,17 +16,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
-        <PackageReference Include="Serilog" Version="3.1.1" />
-        <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Core7Library\Core7Library.csproj" />
+      <ProjectReference Include="..\Core8Library\Core8Library.csproj" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
- .NET 8 class library created where most of this new code is
- New builder that wraps `HostApplicationBuilder`
  - Exposes similar methods as before, but has better guidance/documentation
  - Generally won't let consumer call the wrong things (or neglect to call things that should be called)
- Autofac introduced (from experiments in [Autofac-It-Up](https://github.com/sdepouw/Autofac-It-Up)
- .NET 8 Background Service now uses the `Core8Library`, and no longer directly references NuGet packages itself
- `RefitClientServiceBase` now catches every exception, instead of just `ApiException`
  - We never want these calls throwing, since they potentially cause the whole service to stop
  - Timeouts throw `TaskCanceledException` for example
- A few `TODO`s floating around as notes